### PR TITLE
fix: let get_sdc_for_volume return empty list if no SDCs are mapped

### DIFF
--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -668,12 +668,12 @@ class ScaleIO(SIO_Generic_Object):
         else:
             raise ValueError("Malformed IP address - get_sdc_by_ip()")
     
-    def get_sdc_for_volume(self, volObj):
-        sdcList = []
-        for sdc in volObj.mapped_sdcs:
-            sdcList.append(sdc)
-        #if len(sdcList) == 0:
-        return sdcList
+     def get_sdc_for_volume(self, volObj):
+         sdcList = []
+         if volObj.mapped_sdcs is not None:
+            for sdc in volObj.mapped_sdcs:
+                 sdcList.append(sdc)
+         return sdcList
     
     def get_pd_by_name(self, name):
         for pd in self.protection_domains:


### PR DESCRIPTION
Fix get_sdc_for_volume so that it returns an empty list if there are no SDC's connected. This previous version would fail with `TypeError: 'NoneType' object is not iterable` when trying to do something like delete_volume if no SDCs were attached.

```
>>> from scaleiopy import scaleio
>>> sio = scaleio.ScaleIO("https://192.168.50.12/api","admin","Scaleio123",verify_ssl=False)
2015-05-04 11:48:26,518: DEBUG scaleio:__init__ | Logger initialized!
>>> sio.create_volume_by_pd_name('testvol001', 8192, sio.get_pd_by_name('pdomain'))
.
.
.
<Response [200]>
>>> sio.volumes
.
.
.
mappingToAllSdcsEnabled: False
                    name: testvol001
                 size_kb: 8388608
         storage_pool_id: b731648f00000000
               use_cache: True
             volume_type: ThinProvisioned
                vtree_id: f58a4d1000000001]
.
.
.
>>> sio.delete_volume(sio.get_volume_by_name('testvol001'))
.
.
.
<Response [200]>
>>>
```
