### PR TITLE
fix indentation errors

### DIFF
--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -668,11 +668,11 @@ class ScaleIO(SIO_Generic_Object):
         else:
             raise ValueError("Malformed IP address - get_sdc_by_ip()")
     
-     def get_sdc_for_volume(self, volObj):
-         sdcList = []
-         if volObj.mapped_sdcs is not None:
+    def get_sdc_for_volume(self, volObj):
+        sdcList = []
+        if volObj.mapped_sdcs is not None:
             for sdc in volObj.mapped_sdcs:
-                 sdcList.append(sdc)
+                sdcList.append(sdc)
          return sdcList
     
     def get_pd_by_name(self, name):


### PR DESCRIPTION
off by 1, this was introduced in https://github.com/swevm/scaleio-py/pull/4, about that one, fixing now. Would throw `exceptions.IndentationError: unindent does not match any outer indentation level (scaleio.py, line 671)`
