### PR TITLE
add resize_volume function

### DIFF
--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -780,6 +780,20 @@ class ScaleIO(SIO_Generic_Object):
                                     else:
                                         self.map_volume_to_sdc(self.get_volume_by_name(volName), value)
         return response
+        
+    def resize_volume(self, volumeObj, sizeInGb, bsize=1000):
+        """
+        Resize a volume to new GB size, must be larger than original.
+        """
+        current_vol = self.get_volume_by_id(volumeObj.id)
+        if current_vol.sizeInKb > (sizeInGb * bsize * bsize):
+            raise RuntimeError(
+                "resize_volume() - New size needs to be bigger than: %ds" % current_vol.sizeInKb )
+        
+        resizeDict = { 'sizeInGB' : sizeInGb }
+        response = self._do_post("{}/{}{}/{}".format(
+            self._api_url, "instances/Volume::", volumeObj.id, 'action/setVolumeSize'), json=resizeDict)
+        return response
 
     def map_volume_to_sdc(self, volumeObj, sdcObj=None, allowMultipleMappings=False, **kwargs):
         # TODO:

--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -786,7 +786,7 @@ class ScaleIO(SIO_Generic_Object):
         Resize a volume to new GB size, must be larger than original.
         """
         current_vol = self.get_volume_by_id(volumeObj.id)
-        if current_vol.sizeInKb > (sizeInGb * bsize * bsize):
+        if current_vol.size_kb > (sizeInGb * bsize * bsize):
             raise RuntimeError(
                 "resize_volume() - New size needs to be bigger than: %ds" % current_vol.sizeInKb )
         

--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -790,7 +790,7 @@ class ScaleIO(SIO_Generic_Object):
             raise RuntimeError(
                 "resize_volume() - New size needs to be bigger than: %ds" % current_vol.sizeInKb )
         
-        resizeDict = { 'sizeInGB' : sizeInGb }
+        resizeDict = { 'sizeInGB' : str(sizeInGb) }
         response = self._do_post("{}/{}{}/{}".format(
             self._api_url, "instances/Volume::", volumeObj.id, 'action/setVolumeSize'), json=resizeDict)
         return response

--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -788,7 +788,7 @@ class ScaleIO(SIO_Generic_Object):
         current_vol = self.get_volume_by_id(volumeObj.id)
         if current_vol.size_kb > (sizeInGb * bsize * bsize):
             raise RuntimeError(
-                "resize_volume() - New size needs to be bigger than: %ds" % current_vol.sizeInKb )
+                "resize_volume() - New size needs to be bigger than: %d KBs" % current_vol.size_kb)
         
         resizeDict = { 'sizeInGB' : str(sizeInGb) }
         response = self._do_post("{}/{}{}/{}".format(


### PR DESCRIPTION
added a resize_volume function to this, which calls `/api/instances/Volume::{id}/action/setVolumeSize`

Below is the function working, it will only let the user grow the volume, so it errs if the new volume size isnt big enough.
# testing too small of volume size

```
>>> resp = sio.resize_volume(vol, 24)
2015-05-07 13:07:33,771: DEBUG connectionpool:_make_request | "GET /api/types/Volume/instances HTTP/1.1" 200 None
2015-05-07 13:07:33,773: DEBUG scaleio:_do_get | _do_get() - HTTP response OK, data: [{"creationTime":1430998238,"storagePoolId":"cd50ac0300000000","useRmcache":true,"mappingToAllSdcsEnabled":false,"volumeType":"ThinProvisioned","isObfuscated":false,"consistencyGroupId":null,"vtreeId":"1956ed370000000c","ancestorVolumeId":null,"mappedSdcInfo":null,"mappedScsiInitiatorInfo":null,"sizeInKb":25165824,"name":"f9ExZShkPRr20Soj2jmeVKAcb48cf93","id":"b8f366ff00000001","links":[{"rel":"self","href":"/api/instances/Volume::b8f366ff00000001"},{"rel":"/api/Volume/relationship/Statistics","href":"/api/instances/Volume::b8f366ff00000001/relationships/Statistics"},{"rel":"/api/parent/relationship/vtreeId","href":"/api/instances/VTree::1956ed370000000c"},{"rel":"/api/parent/relationship/storagePoolId","href":"/api/instances/StoragePool::cd50ac0300000000"}]},{"creationTime":1430998239,"storagePoolId":"cd50ac0300000000","useRmcache":true,"mappingToAllSdcsEnabled":false,"volumeType":"ThinProvisioned","isObfuscated":false,"consistencyGroupId":null,"vtreeId":"1956ed3a0000000f","ancestorVolumeId":null,"mappedSdcInfo":null,"mappedScsiInitiatorInfo":null,"sizeInKb":33554432,"name":"fXFPD1t0eRfKHMPbBnOZv4wb07a4b99","id":"b8f3670200000002","links":[{"rel":"self","href":"/api/instances/Volume::b8f3670200000002"},{"rel":"/api/Volume/relationship/Statistics","href":"/api/instances/Volume::b8f3670200000002/relationships/Statistics"},{"rel":"/api/parent/relationship/vtreeId","href":"/api/instances/VTree::1956ed3a0000000f"},{"rel":"/api/parent/relationship/storagePoolId","href":"/api/instances/StoragePool::cd50ac0300000000"}]}]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "scaleiopy/scaleio.py", line 791, in resize_volume
    "resize_volume() - New size needs to be bigger than: %d KBs" % current_vol.size_kb)
RuntimeError: resize_volume() - New size needs to be bigger than: 33554432 KBs
```
# adding new volume size that grows volume

```
>>> resp = sio.resize_volume(vol, 40)
2015-05-07 13:07:42,081: DEBUG connectionpool:_make_request | "GET /api/types/Volume/instances HTTP/1.1" 200 None
2015-05-07 13:07:42,083: DEBUG scaleio:_do_get | _do_get() - HTTP response OK, data: [{"creationTime":1430998238,"storagePoolId":"cd50ac0300000000","useRmcache":true,"mappingToAllSdcsEnabled":false,"volumeType":"ThinProvisioned","isObfuscated":false,"consistencyGroupId":null,"vtreeId":"1956ed370000000c","ancestorVolumeId":null,"mappedSdcInfo":null,"mappedScsiInitiatorInfo":null,"sizeInKb":25165824,"name":"f9ExZShkPRr20Soj2jmeVKAcb48cf93","id":"b8f366ff00000001","links":[{"rel":"self","href":"/api/instances/Volume::b8f366ff00000001"},{"rel":"/api/Volume/relationship/Statistics","href":"/api/instances/Volume::b8f366ff00000001/relationships/Statistics"},{"rel":"/api/parent/relationship/vtreeId","href":"/api/instances/VTree::1956ed370000000c"},{"rel":"/api/parent/relationship/storagePoolId","href":"/api/instances/StoragePool::cd50ac0300000000"}]},{"creationTime":1430998239,"storagePoolId":"cd50ac0300000000","useRmcache":true,"mappingToAllSdcsEnabled":false,"volumeType":"ThinProvisioned","isObfuscated":false,"consistencyGroupId":null,"vtreeId":"1956ed3a0000000f","ancestorVolumeId":null,"mappedSdcInfo":null,"mappedScsiInitiatorInfo":null,"sizeInKb":33554432,"name":"fXFPD1t0eRfKHMPbBnOZv4wb07a4b99","id":"b8f3670200000002","links":[{"rel":"self","href":"/api/instances/Volume::b8f3670200000002"},{"rel":"/api/Volume/relationship/Statistics","href":"/api/instances/Volume::b8f3670200000002/relationships/Statistics"},{"rel":"/api/parent/relationship/vtreeId","href":"/api/instances/VTree::1956ed3a0000000f"},{"rel":"/api/parent/relationship/storagePoolId","href":"/api/instances/StoragePool::cd50ac0300000000"}]}]
2015-05-07 13:07:42,115: DEBUG connectionpool:_make_request | "POST /api/instances/Volume::b8f3670200000002/action/setVolumeSize HTTP/1.1" 200 None
2015-05-07 13:07:42,116: DEBUG scaleio:_do_post | _do_post() - HTTP response: {}
2015-05-07 13:07:42,117: DEBUG scaleio:_do_post | _do_post() - HTTP response OK, data: {}
>>>
```
