### PR TITLE
Add Faultset capability

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,7 +28,7 @@ Initial code to test integration against ScaleIO API
 * Auto unmap of SDC when deleting volume that have existing mappings
 * Error checking (basics) - Might be pushed to v0.3+
 * Make naming of methods and attributes consistent (match to ScaleIO API documentation) - Might be pushed to v0.3+
-* Statistics gathering (maybe in 0.3+)
+* Statistics gathering (maybe in 0.3+ likely 0.4)
 * Add a changelog
 * IM integration to install new cluster
 * Add examples
@@ -44,6 +44,8 @@ Initial code to test integration against ScaleIO API
 * Delete ProtectionDomain (WIP)
 * Create FaultSet (WIP)
 * Delete FaultSet (WIP)
+* set name functionality for FS, PD, SDC and SDS
+* 
 
 
 ## v0.3+

--- a/examples/connect-cluster.py
+++ b/examples/connect-cluster.py
@@ -4,10 +4,17 @@ from pprint import pprint
 import sys
 
 
-logging.basicConfig(format='%(asctime)s: %(levelname)s %(module)s:%(funcName)s | %(message)s', level=logging.DEBUG)
+logging.basicConfig(format='%(asctime)s: %(levelname)s %(module)s:%(funcName)s | %(message)s', level=logging.WARNING)
 sio = scaleio.ScaleIO("https://" + sys.argv[1] + "/api",sys.argv[2], sys.argv[3] ,verify_ssl=False) # HTTPS must be used as there seem to be an issue with 302 responses in Requests when using POST
+print "--- ScaleIO System ---"
 pprint(sio.system)
+print "--- ScaleIO SDC ---"
 pprint(sio.sdc)
+print "--- ScaleIO SDS ---"
 pprint(sio.sds)
+print  "--- ScaleiO Volumes ---"
 pprint(sio.volumes)
+print "--- ScaleIO Protection Domains ---"
 pprint(sio.protection_domains)
+print "--- ScaleIO Fault Sets ---"
+pprint(sio.fault_sets)

--- a/examples/create-volume.py
+++ b/examples/create-volume.py
@@ -12,5 +12,5 @@ import sys
 logging.basicConfig(format='%(asctime)s: %(levelname)s %(module)s:%(funcName)s | %(message)s', level=logging.WARNING)
 sio = scaleio.ScaleIO("https://" + sys.argv[1] + "/api",sys.argv[2],sys.argv[3],verify_ssl=False) # HTTPS must be used as there seem to be an issue with 302 responses in Requests when using POST
     
-sio.create_volume_by_pd_name(sys.argv[4], 8192, sio.get_pd_by_name(sys.argv[5]))
+sio.create_volume(sys.argv[4], 8192, sio.get_pd_by_name(sys.argv[5]))
 pprint(sio.volumes)

--- a/examples/create_map-volume.py
+++ b/examples/create_map-volume.py
@@ -12,6 +12,6 @@ import sys
 logging.basicConfig(format='%(asctime)s: %(levelname)s %(module)s:%(funcName)s | %(message)s', level=logging.WARNING)
 sio = scaleio.ScaleIO("https://" + sys.argv[1] + "/api",sys.argv[2],sys.argv[3],verify_ssl=False) # HTTPS must be used as there seem to be an issue with 302 responses in Requests when using POST
     
-sio.create_volume_by_pd_name(sys.argv[4], 8192, sio.get_pd_by_name(sys.argv[5]), mapAll=True)
+sio.create_volume(sys.argv[4], 8192, sio.get_pd_by_name(sys.argv[5]), mapAll=True)
 
 pprint(sio.volumes)

--- a/examples/create_mapall-volume.py
+++ b/examples/create_mapall-volume.py
@@ -12,6 +12,6 @@ import sys
 logging.basicConfig(format='%(asctime)s: %(levelname)s %(module)s:%(funcName)s | %(message)s', level=logging.WARNING)
 sio = scaleio.ScaleIO("https://" + sys.argv[1] + "/api",sys.argv[2],sys.argv[3],verify_ssl=False) # HTTPS must be used as there seem to be an issue with 302 responses in Requests when using POST
     
-sio.create_volume_by_pd_name(sys.argv[4], 8192, sio.get_pd_by_name(sys.argv[5]), mapAll=True)
+sio.create_volume(sys.argv[4], 8192, sio.get_pd_by_name(sys.argv[5]), mapAll=True)
 
 pprint(sio.volumes)

--- a/examples/install-cluster-faultsets.py
+++ b/examples/install-cluster-faultsets.py
@@ -1,0 +1,133 @@
+from scaleiopy import im
+from scaleiopy import scaleioobject as sioobj
+#from scaleio import installerfsm as instfsm
+import time
+import json
+from pprint import pprint
+
+###########################
+# Create a ScaleIO System #
+###########################
+#
+# Prereq: 3 x CentOS 6.5 or RHEL 6.5
+#
+# Flow:
+# Create Nodes
+# Create basic info. mdmPass, liaPass and some others
+# Construct MDM and TB and basic info
+# Create list of SDS
+# Create list of SDC
+
+
+###################
+# Construct nodes #
+###################
+nodeUsername = 'root' # Username for ScaleIO Node OS (these machines need to be pre installed)
+nodePassword = 'vagrant' # Password for ScaleIO Node OS
+node1 = sioobj.ScaleIO_Node_Object(None, None, ['192.168.102.11'], None, 'linux', nodePassword, nodeUsername)
+node2 = sioobj.ScaleIO_Node_Object(None, None, ['192.168.102.12'], None, 'linux', nodePassword, nodeUsername)
+node3 = sioobj.ScaleIO_Node_Object(None, None, ['192.168.102.13'], None, 'linux', nodePassword, nodeUsername)
+    
+##########################################
+# Construct basic info for System_Object #
+##########################################
+mdmIPs = ['192.168.102.12','192.168.102.13']
+sdcList = []
+sdsList = []
+mdmPassword = 'Scaleio123'
+liaPassword = 'Scaleio123'
+licenseKey = None
+installationId = None
+
+########################################
+# Create MDMs and TB for System_Object #
+########################################
+primaryMdm = sioobj.Mdm_Object(json.loads(node2.to_JSON()), None, None, node2.nodeIPs)
+secondaryMdm = sioobj.Mdm_Object(json.loads(node3.to_JSON()), None, None, node3.nodeIPs)
+tb = sioobj.Tb_Object(json.loads(node1.to_JSON()), None, node1.nodeIPs)
+callHomeConfiguration = None # {'callHomeConfiguration':'None'}
+remoteSyslogConfiguration = None # {'remoteSysogConfiguration':'None'}
+
+################################################################
+#Create SDS objects - To be added to SDS list in System_Object #
+################################################################
+# Adjust addDevice() to match local block device you have in your node
+# Define SDS that belong to a FaultSet - Not tested!
+#sds1 = sioobj.Sds_Object(json.loads(node1.to_JSON()), None, 'SDS_' + str(node1.nodeIPs[0]), 'default', 'faultset1', node1.nodeIPs, None, None, None, False, '7072')
+
+sds1 = sioobj.Sds_Object(json.loads(node1.to_JSON()), None, 'SDS_' + str(node1.nodeIPs[0]), 'default', 'faultset1', node1.nodeIPs, None, None, None, False, '7072')
+sds1.addDevice("/home/vagrant/scaleio1", None, None)
+sds2 = sioobj.Sds_Object(json.loads(node2.to_JSON()), None, 'SDS_' + str(node2.nodeIPs[0]), 'default', 'faultset2', node2.nodeIPs, None, None, None, False, '7072')
+sds2.addDevice("/home/vagrant/scaleio1", None, None)
+sds3 = sioobj.Sds_Object(json.loads(node3.to_JSON()), None, 'SDS_' + str(node3.nodeIPs[0]), 'default', 'faultset3', node3.nodeIPs, None, None, None, False, '7072')
+sds3.addDevice("/home/vagrant/scaleio1", None, None)
+sdsList.append(json.loads(sds1.to_JSON()))
+sdsList.append(json.loads(sds2.to_JSON()))
+sdsList.append(json.loads(sds3.to_JSON()))
+
+#############################################################
+# Create SDC objects - To be added as list to System_Object #
+#############################################################
+# Decide which nodes in your cluster should become a SDC
+"""
+node=None,
+nodeInfo=None,
+splitterRpaIp=None
+"""
+sdc1 = sioobj.Sdc_Object(json.loads(node1.to_JSON()), None, None)
+sdc2 = sioobj.Sdc_Object(json.loads(node2.to_JSON()), None, None)
+sdc3 = sioobj.Sdc_Object(json.loads(node3.to_JSON()), None, None)
+
+sdcList.append(json.loads(sdc1.to_JSON()))
+sdcList.append(json.loads(sdc2.to_JSON()))
+sdcList.append(json.loads(sdc3.to_JSON()))
+
+######################################################
+# Construct a complete ScaleIO cluster configuration #
+######################################################
+sioobj = sioobj.ScaleIO_System_Object(installationId,
+                               mdmIPs,
+                               mdmPassword,
+                               liaPassword,
+                               licenseKey,
+                               json.loads(primaryMdm.to_JSON()),
+                               json.loads(secondaryMdm.to_JSON()),
+                               json.loads(tb.to_JSON()),
+                               sdsList,
+                               sdcList,
+                               callHomeConfiguration,
+                               remoteSyslogConfiguration
+                               )
+
+# Export sioobj to JSON (should upload clean in IM)
+
+
+###########################################################################
+# Push System_Object JSON - To be used by IM to install ScaleIO on nodes #
+###########################################################################
+
+
+
+#######################
+# LOGIN TO SCALEIO IM #
+#######################
+imconn = im.Im("https://192.168.102.12","admin","Scaleio123",verify_ssl=False) # "Password1!") # HTTPS must be used as there seem to be an issue with 302 responses in Requests when using POST
+imconn._login()
+
+### UPLOAD RPM PACKAGES TO BE DEPLOYED BY IM ###
+imconn.uploadPackages('/Users/swevm/Downloads/RHEL6_1277/') # Adjust to your needs. All RPMs for RHEL6 should exist in this dir except for GUI and Gateway
+
+####################
+# INSTALLER STAGES #
+####################
+
+# Initialize Installer
+im_installer = im.InstallerFSM(imconn, True)
+
+time.sleep(10) # Wait a few seconds before continuing - Not necessary
+
+print "Create minimal cluster as Python objects"
+imconn.push_cluster_configuration(sioobj.to_JSON())
+
+print "Start Install process!!!"
+im_installer.Execute() # Start install process

--- a/examples/install-cluster.py
+++ b/examples/install-cluster.py
@@ -52,6 +52,9 @@ remoteSyslogConfiguration = None # {'remoteSysogConfiguration':'None'}
 #Create SDS objects - To be added to SDS list in System_Object #
 ################################################################
 # Adjust addDevice() to match local block device you have in your node
+# Define SDS that belong to a FaultSet - Not tested!
+#sds1 = sioobj.Sds_Object(json.loads(node1.to_JSON()), None, 'SDS_' + str(node1.nodeIPs[0]), 'default', 'faultset1', node1.nodeIPs, None, None, None, False, '7072')
+
 sds1 = sioobj.Sds_Object(json.loads(node1.to_JSON()), None, 'SDS_' + str(node1.nodeIPs[0]), 'default', None, node1.nodeIPs, None, None, None, False, '7072')
 sds1.addDevice("/home/vagrant/scaleio1", None, None)
 sds2 = sioobj.Sds_Object(json.loads(node2.to_JSON()), None, 'SDS_' + str(node2.nodeIPs[0]), 'default', None, node2.nodeIPs, None, None, None, False, '7072')

--- a/examples/test-create_map-volume.py
+++ b/examples/test-create_map-volume.py
@@ -12,5 +12,5 @@ import sys
 logging.basicConfig(format='%(asctime)s: %(levelname)s %(module)s:%(funcName)s | %(message)s', level=logging.WARNING)
 sio = scaleio.ScaleIO("https://" + sys.argv[1] + "/api",sys.argv[2],sys.argv[3],verify_ssl=False) # HTTPS must be used as there seem to be an issue with 302 responses in Requests when using POST
     
-sio.create_volume_by_pd_name(sys.argv[4], int(sys.argv[6]), sio.get_pd_by_name(sys.argv[5]), True, mapAll=True)
+sio.create_volume(sys.argv[4], int(sys.argv[6]), sio.get_pd_by_name(sys.argv[5]), True, mapAll=True)
 pprint(sio.volumes)

--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -338,6 +338,27 @@ class ScaleIO_SDS(SIO_Generic_Object):
         JSON response from the server.
         """
         return ScaleIO_SDS(**dict)
+ 
+class ScaleIO_Fault_Set(SIO_Generic_Object):
+    """ ScaleIO Faultset Class repreentation """
+    
+    def __init__(self,
+        id=None,
+        name=None,
+        protectionDomainId=None
+
+    ):
+        self.id=id
+        self.name=name
+        self.protectionDomainId=protectionDomainId
+
+    @staticmethod
+    def from_dict(dict):
+        """
+        A convinience method that directly creates a new instance from a passed dictionary (that probably came from a
+        JSON response from the server.
+        """
+        return ScaleIO_Fault_Set(**dict)
     
 class SnapshotSpecification(SIO_Generic_Object):
     """
@@ -595,7 +616,7 @@ class ScaleIO(SIO_Generic_Object):
     @property
     def protection_domains(self):
         """
-        :rtype: list
+        :rtype: list of Protection Domains
         """
         self._check_login()
         response = self._do_get("{}/{}".format(self._api_url, "types/ProtectionDomain/instances")).json()
@@ -606,11 +627,44 @@ class ScaleIO(SIO_Generic_Object):
             )
         return all_pds
 
+    @property
+    def fault_sets(self):
+        """
+        :rtype: list of Faultsets
+        
+        
+        You can only create and configure Fault Sets before adding SDSs to the system, and configuring them incorrectly
+        may prevent the creation of volumes. An SDS can only be added to a Fault Set during the creation of the SDS.
+
+        """
+        self._check_login()
+        response = self._do_get("{}/{}".format(self._api_url, "types/FaultSet/instances")).json()
+        all_faultsets = []
+        for fss in response:
+            all_faultsets.append(
+                ScaleIO_Fault_Set.from_dict(pd)
+            )
+        return all_faultsets
+
     def get_system_objects(self):
         return self.system
     
     def get_system_id(self):
         return self.system[0].id
+        
+        
+    def get_sds_in_faultset(self, faultSetObj):
+        """
+        :rtype: list of SDS in specified Faultset
+        """
+        self._check_login()
+        response = self._do_get("{}/{}{}/{}".format(self._api_url, 'types/FaultSet::', faultSetObj.id, 'relationships/Sds')).json()
+        all_sds = []
+        for fss in response:
+            all_sds.append(
+                ScaleIO_SDS.from_dict(pd)
+            )
+        return all_sds        
         
     def get_sds_by_name(self,name):
         for sds in self.sds:
@@ -679,30 +733,42 @@ class ScaleIO(SIO_Generic_Object):
         for pd in self.protection_domains:
             if pd.name == name:
                 return pd
-        raise KeyError("Protection Domain of that name not found")
+        raise KeyError("Protection Domain NAME " + name + " not found")
 
     def get_pd_by_id(self, id):
         for pd in self.protection_domains:
             if pd.id == id:
                 return pd
-        raise KeyError("Protection Domain with that ID not found")
+        raise KeyError("Protection Domain with ID " + id + " not found")
     
     def get_volume_by_id(self, id):
         for vol in self.volumes:
             if vol.id == id:
                 return vol
-        raise KeyError("Volume with that ID not found")
+        raise KeyError("Volume with ID " + id + " not found")
 
     def get_volume_by_name(self, name):
         for vol in self.volumes:
             if vol.name == name:
                 return vol
-        raise KeyError("Volume with that NAME not found")
+        raise KeyError("Volume with NAME " + name + " not found")
     
     def get_volume_all_sdcs_mapped(self, volObj):
         if volObj.mappingToAllSdcsEnabled == True:
             return True
         return False
+    
+    def get_faultset_by_id(self,id):
+        for fs in self.fault_sets:
+            if fs.id == id:
+                return fs
+        raise KeyError("FaultSet with ID " + id + " not found")
+
+    def get_faultset_by_name(self,name):
+        for fs in self.fault_sets:
+            if fs.name == name:
+                return fs
+        raise KeyError("FaultSet with NAME " + name + " not found")
     
     def get_snapshot_by_vol_name(self, volObj):
         pass
@@ -718,6 +784,26 @@ class ScaleIO(SIO_Generic_Object):
     
     def get_snapshot_group_id_by_vol_id(self, volObj):
         pass
+    
+    def create_protection_domain(self, pdObj, **kwargs):
+        # TODO:
+        # Check if object parameters are the correct ones
+        self._check_login()    
+        response = self._do_post("{}/{}".format(self._api_url, "types/Volume/instances"), json=pdObj.__to_dict__()())
+        return response
+    
+    def delete_potection_domain(self, pdObj):
+        """
+        :param pdObj: ID of ProtectionDomain
+        
+        type: POST
+        Required:
+            Protection Domain Object
+        Return:
+        """
+        self._check_login()
+        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/ProtectionDomain::", pdObj.id, 'action/removeProtectionDomain'))
+        return response
     
     def create_snapshot(self, systemId, snapshotSpecificationObject):
         """
@@ -860,31 +946,70 @@ class ScaleIO(SIO_Generic_Object):
             raise RuntimeError("delete_volume() - Communication error with ScaleIO Gateway")
         return response
     
- 
-    def delete_sdc_from_cluster(self, sdcObj):
-        # TODO:
+    """
+    def delete_sdc_from_cluster(self, sdcObj): 
+        # DEPRECEATED
         # Check if object parameters are the correct ones, otherwise throw error
         self._check_login() 
         response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sdc::", sdcObj.id, 'action/removeSdc'))    
         return response  
+    """
+    
+    def set_sds_name(self, name, sdsObj):
+        # TODO:
+        # Check if object parameters are the correct type, otherwise throw error
+        # UNSURE IF THIS IS CORRECT WAY TO SET SDS NAME
+        self._check_login()
+        sdsNameDict = {'sdsName': name}
+        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sds::", sdcObj.id, 'action/setSdsName'), json=sdsNameDict)    
+        return response
 
     def set_sdc_name(self, name, sdcObj):
         # TODO:
         # Check if object parameters are the correct ones, otherwise throw error
         self._check_login()
-        deleteVolumeDict = {'sdcName': name}
-        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sdc::", sdcObj.id, 'action/setSdcName'), json=unmapVolumeFromSdcDict)    
+        sdcNameDict = {'sdcName': name}
+        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sdc::", sdcObj.id, 'action/setSdcName'), json=sdcNameDict)    
         return response
-    
-    #def set_volume_map_to_all_sdcs(self, volObj, enabled=False):
-    #    self._check_login()
-    # Research: Can there still exsit individual SDC mappings? API Guide say nothing about it.
-    #    return self.map_volume_to_sdc(volobj, mapAll=True)
+
+    def set_faultset_name(self, name, fsObj):
+        # Set name of FaultSet
+        self._check_login()
+        faultSetNameDict = {'Name': name}
+        # This one is the most logical name comparing to other methods.
+        response = self._do_post("{}/{}{}/{}".format(self._api_url, "types/FaultSet::", fsObj.id, 'instances/action/setFaultSetName'), json=faultSetNameSdcDict)    
+
+        # This is how its documened in REST API Chapter
+        #response = self._do_post("{}/{}{}/{}".format(self._api_url, "types/FaultSet::", fsObj.id, 'instances/action/setFaultSetName'), json=faultsetNameSdcDict)    
+        return response    
     
     def unregisterSdc(self, sdcObj):
         self._check_login()
-        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sdc::", sdcObj.id, 'action/removeSdc'), json=unmapVolumeFromSdcDict)    
+        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sdc::", sdcObj.id, 'action/removeSdc'))    
         return response
+
+    def registerSdc(self, sdcObj, **kwargs):
+        # Register existing SDS running SDS binary (need to be installed manually but not added to MDM)
+        # 
+        self._check_login()    
+
+        response = self._do_post("{}/{}".format(self._api_url, "types/Sdc/instances"), json=sdcObj.__to_dict__())
+        return response
+
+    def unregisterSds(self, sdsObj):
+        self._check_login()
+        response = self._do_post("{}/{}{}/{}".format(self._api_url, "instances/Sds::", sdsObj.id, 'action/removeSds'))    
+        return response    
+    
+    # /api/types/Sds/instance s
+    def registerSds(self, sdsObj, **kwargs):
+        # Register existing SDS running SDS binary (need to be installed manually but not added to MDM)
+        # 
+        self._check_login()    
+
+        response = self._do_post("{}/{}".format(self._api_url, "types/Sds/instances"), json=sdsObj.__to_dict__())
+        return response
+    
     
     def is_ip_addr(self, ipstr):
         """

--- a/scaleiopy/scaleioobject.py
+++ b/scaleiopy/scaleioobject.py
@@ -183,7 +183,8 @@ class Sdc_Object(Im_Generic_Object):
 
 class Sds_Device_Object(Im_Generic_Object):
     """
-    Python object representation of a MDM (primary or secondary look eactly the same configuration wise).
+    Python object representation of a SDS Device
+
     """
     
     def __init__(self,
@@ -206,6 +207,8 @@ class Sds_Device_Object(Im_Generic_Object):
 class Sds_Object(Im_Generic_Object):
     """
     Python object representation of a SDS.
+    To add a SDS to a faultset this is where its done. SDSs cannot be added to FaultSets after they have been added to protectiondomain. API wise they can be removed and re added (not sure how re-add is done though)
+    
     """
     
     def __init__(self,
@@ -225,7 +228,7 @@ class Sds_Object(Im_Generic_Object):
         self.nodeInfo=nodeInfo
         self.sdsName=sdsName
         self.protectionDomain = protectionDomain
-        self.faultSet=faultSet
+        self.faultSet=faultSet # Is this as easy as giving a string with a Faultset name??? (Its not documented)
         self.allIPs=[]
         for allIp in allIPs:
             self.allIPs.append(allIp)


### PR DESCRIPTION
Add capabilities to work with Faultsets.

Additions:
- Example of how to install ScaleIO cluster with 3x Faultsets
- Set name for SDC, SDC, FS, PD
- get functions for FS
- Minor cleanups
- Change name of create_volume_by_pd_name() -> create_volume()
