### PR TITLE
add guid to sdc object

### DIFF
--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -273,6 +273,7 @@ class ScaleIO_SDC(SIO_Generic_Object):
         self.name = name
         self.mdmConnectionState = mdmConnectionState
         self.sdcIp = sdcIp
+        self.guid = sdcGuid
         self.links = []
         for link in links:
             self.links.append(Link(link['href'], link['rel']))
@@ -789,6 +790,19 @@ class ScaleIO(SIO_Generic_Object):
             if sdc.id == id:
                 return sdc
         raise KeyError("SDC with that ID not found")
+
+    def get_sdc_by_guid(self, guid):
+        """
+        Get ScaleIO SDC object by its id
+        :param name: guid of SDC
+        :return: ScaleIO SDC object
+        :raise KeyError: No SDC with specified id found
+        :rtype: SDC object
+        """
+        for sdc in self.sdc:
+            if sdc.guid == guid:
+                return sdc
+        raise KeyError("SDC with that GUID not found")
 
     def get_sdc_by_ip(self, ip):
         """


### PR DESCRIPTION
had a need to get an sdc by its GUID, added the ability to do so. 

example

```
>>> sio.get_sdc_by_guid("C1892D0B-99FF-4B7C-8DC2-26572C91905B")
<ScaleIO_SDC> @ 15323280:
                    guid: C1892D0B-99FF-4B7C-8DC2-26572C91905B
                      id: 605b5ad700000002
                   links: [Link : Target: '/api/instances/Sdc::605b5ad700000002' Relative: 'self', Link : Target: '/api/instances/Sdc::605b5ad700000002/relationships/Statistics' Relative: '/api/Sdc/relationship/Statistics', Link : Target: '/api/instances/Sdc::605b5ad700000002/relationships/Volume' Relative: '/api/Sdc/relationship/Volume', Link : Target: '/api/instances/System::4713fba2003dba45' Relative: '/api/parent/relationship/systemId']
      mdmConnectionState: Connected
                    name: None
                   sdcIp: 192.168.50.13
```
