### PR TITLE
add error logs to runtime error in _do_X

### DIFF
--- a/scaleiopy/scaleio.py
+++ b/scaleiopy/scaleio.py
@@ -577,7 +577,8 @@ class ScaleIO(SIO_Generic_Object):
                 self.logger.error('_do_get() - HTTP response error: %s', response.status_code)
                 self.logger.error('_do_get() - HTTP response error, data: %s', response.text)                
                 raise RuntimeError("_do_get() - HTTP response error" + response.status_code)
-        except:
+        except Exception as e:
+            self.logger.error("_do_get() - Unhandled Error Occurred: %s" % str(e)) 
             raise RuntimeError("_do_get() - Communication error with ScaleIO gateway")
         return response
 
@@ -599,7 +600,8 @@ class ScaleIO(SIO_Generic_Object):
                 self.logger.error('_do_post() - HTTP response error: %s', response.status_code)
                 self.logger.error('_do_post() - HTTP response error, data: %s', response.text)                
                 raise RuntimeError("_do_post() - HTTP response error" + response.status_code)
-        except:
+        except Exception as e:
+            self.logger.error("_do_post() - Unhandled Error Occurred: %s" % str(e)) 
             raise RuntimeError("_do_post() - Communication error with ScaleIO gateway")
         return response
 


### PR DESCRIPTION
Its hard to debug whats going on when you always get `_do_post() - Communication error with ScaleIO gateway`. This adds the actual error to the log and will help debug. Came across and SSL / Cert error recently that wasn't caught so I was only getting the above string for an error.
